### PR TITLE
Remove binary placeholder assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# codex-suzuki-stretching
+# Suzuki Stretch Coach
+
+This repository contains the static Suzuki Stretch Coach application. Binary assets have been intentionally removed; please add your own PDF and exercise imagery before deployment. Replace the placeholder text file at `assets/Suzukiho-strecink.pdf` with the authentic document so the download link functions.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,920 @@
+import { initRouter, navigate, getCurrentRoute } from './router.js';
+import { initI18n, t, setLang, getLang, onLangChange } from './i18n.js';
+import { rules } from './src/rules.js';
+
+const STATE_KEY = 'ssc-state-v1';
+const appRoot = document.getElementById('app');
+const modalRoot = document.getElementById('modal-root');
+
+const defaultState = {
+  lang: 'cs',
+  goal: 'obecna',
+  minutesPerDay: 15,
+  partnerMode: false,
+  sound: false,
+  reminderTime: '',
+  startSide: 'left',
+  logs: {
+    sessions: [],
+    backOff: []
+  }
+};
+
+let state = loadState();
+let exercises = [];
+let dataReady = false;
+let sessionCtx = null;
+let timerInterval = null;
+let breathInterval = null;
+let audioContext;
+
+const stateListeners = new Set();
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(STATE_KEY);
+    if (!raw) return cloneState(defaultState);
+    const parsed = JSON.parse(raw);
+    return {
+      ...defaultState,
+      ...parsed,
+      logs: {
+        sessions: parsed?.logs?.sessions || [],
+        backOff: parsed?.logs?.backOff || []
+      }
+    };
+  } catch (err) {
+    console.warn('Failed to load state', err);
+    return cloneState(defaultState);
+  }
+}
+
+function persistState() {
+  localStorage.setItem(STATE_KEY, JSON.stringify(state));
+}
+
+function subscribeState(listener) {
+  stateListeners.add(listener);
+  return () => stateListeners.delete(listener);
+}
+
+function notifyState() {
+  persistState();
+  for (const listener of stateListeners) {
+    listener(state);
+  }
+}
+
+function updateState(updater) {
+  const draft = JSON.parse(JSON.stringify(state));
+  const result = updater ? updater(draft) || draft : draft;
+  state = result;
+  notifyState();
+}
+
+function getState() {
+  return state;
+}
+
+function cloneState(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+initI18n();
+if (state.lang && state.lang !== getLang()) {
+  setLang(state.lang);
+} else {
+  updateState((draft) => {
+    draft.lang = getLang();
+    return draft;
+  });
+}
+
+onLangChange((lang) => {
+  if (getState().lang !== lang) {
+    updateState((draft) => {
+      draft.lang = lang;
+      return draft;
+    });
+  }
+  renderNav();
+  renderRoute(getCurrentRoute());
+});
+
+fetch('data/exercises.json')
+  .then((res) => res.json())
+  .then((json) => {
+    exercises = json;
+    dataReady = true;
+    renderNav();
+    renderRoute(getCurrentRoute());
+  })
+  .catch((err) => {
+    console.error('Failed to load exercises', err);
+  });
+
+initRouter((path) => {
+  if (getCurrentRoute() === '/session' && path !== '/session') {
+    teardownSession();
+  }
+  renderRoute(path);
+});
+
+subscribeState((next) => {
+  if (getCurrentRoute() !== '/session') {
+    renderRoute(getCurrentRoute());
+  }
+  renderNav();
+});
+
+function renderNav() {
+  const nav = document.querySelector('.nav');
+  if (!nav) return;
+  const links = nav.querySelectorAll('a');
+  const labels = ['nav.home', 'nav.session', 'nav.exercises', 'nav.settings', 'nav.progress'];
+  links.forEach((link, idx) => {
+    if (labels[idx]) {
+      link.textContent = t(labels[idx]);
+    }
+  });
+  const brand = document.querySelector('.brand');
+  if (brand) brand.textContent = 'Suzuki Stretch Coach';
+}
+
+function renderRoute(path) {
+  if (!dataReady && path !== '/settings' && path !== '/') {
+    appRoot.innerHTML = `<section class="card"><h1>Suzuki Stretch Coach</h1><p>Načítání dat…</p></section>`;
+    return;
+  }
+  switch (path) {
+    case '/session':
+      renderSession();
+      break;
+    case '/exercises':
+      renderExercises();
+      break;
+    case '/settings':
+      renderSettings();
+      break;
+    case '/progress':
+      renderProgress();
+      break;
+    case '/':
+    default:
+      renderHome();
+      break;
+  }
+}
+
+function renderHome() {
+  const reminder = state.reminderTime;
+  const reminderLabel = reminder
+    ? t('home.todayReminder', { time: reminder })
+    : t('home.noReminder');
+  appRoot.innerHTML = `
+    <section class="card">
+      <h1>${t('home.title')}</h1>
+      <p>${t('home.streak')}</p>
+      <div class="mini-heatmap" aria-label="${t('home.streak')}">
+        ${buildMiniHeatmap()}
+      </div>
+      <div class="cta-group" style="display:grid;gap:0.75rem;margin-top:1.25rem;">
+        <button class="btn" data-action="start">${t('home.start')}</button>
+        <button class="btn btn--secondary" data-action="rules">${t('home.rules')}</button>
+        <a class="btn btn--ghost" href="assets/Suzukiho-strecink.pdf" download>
+          ${t('home.openPdf')}
+        </a>
+      </div>
+      <div class="reminder-banner" role="status">
+        <strong>${t('home.reminder')}:</strong> ${reminderLabel}
+      </div>
+    </section>
+  `;
+  const startBtn = appRoot.querySelector('[data-action="start"]');
+  startBtn?.addEventListener('click', () => navigate('/session'));
+  const rulesBtn = appRoot.querySelector('[data-action="rules"]');
+  rulesBtn?.addEventListener('click', () => openRulesModal());
+}
+
+function buildMiniHeatmap() {
+  const days = 7;
+  const today = new Date();
+  const sessions = state.logs.sessions || [];
+  const completions = new Set(sessions.map((s) => s.date));
+  const weekdays = getLang() === 'cs' ? ['Po', 'Út', 'St', 'Čt', 'Pá', 'So', 'Ne'] : ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  let html = '';
+  for (let i = days - 1; i >= 0; i -= 1) {
+    const d = new Date();
+    d.setDate(today.getDate() - i);
+    const key = formatDateKey(d);
+    const active = completions.has(key);
+    const label = `${weekdays[d.getDay() === 0 ? 6 : d.getDay() - 1]} ${key}`;
+    html += `<div class="mini-heatmap__day${active ? ' active' : ''}" aria-label="${label}">${d.getDate()}</div>`;
+  }
+  return html;
+}
+
+function renderExercises() {
+  if (!dataReady) {
+    appRoot.innerHTML = `<section class="card"><p>Načítání…</p></section>`;
+    return;
+  }
+  const lang = getLang();
+  const partnerEnabled = state.partnerMode;
+  const list = exercises
+    .map((exercise, idx) => {
+      const name = exercise.name[lang];
+      const cues = exercise.cues[lang];
+      const tag = exercise.asym ? t('exercises.asym') : t('exercises.sym');
+      return `
+        <article class="exercise-item" data-id="${exercise.id}">
+          <img src="${exercise.image}" alt="${name}" loading="lazy" />
+          <div class="exercise-item__body">
+            <div class="exercise-item__header">
+              <h2>${idx + 1}. ${name}</h2>
+              <span class="badge">${tag}</span>
+            </div>
+            <div>
+              <strong>${t('exercises.cues')}:</strong>
+              <ul class="cue-list">
+                ${cues.map((cue) => `<li>${cue}</li>`).join('')}
+              </ul>
+            </div>
+          </div>
+        </article>
+      `;
+    })
+    .join('');
+  appRoot.innerHTML = `
+    <section class="card">
+      <h1>${t('exercises.title')}</h1>
+      <div class="exercises-list">${list}</div>
+    </section>
+  `;
+}
+
+function renderSettings() {
+  appRoot.innerHTML = `
+    <section class="card">
+      <h1>${t('settings.title')}</h1>
+      <form class="settings-form">
+        <div class="settings-group">
+          <label for="goal-select">${t('settings.goalLabel')}</label>
+          <select id="goal-select" name="goal">
+            <option value="obecna">${t('settings.goalMobility')}</option>
+            <option value="most">${t('settings.goalBridge')}</option>
+            <option value="provaz">${t('settings.goalSplit')}</option>
+          </select>
+        </div>
+        <div class="settings-group">
+          <label for="minutes-select">${t('settings.minutes')}</label>
+          <select id="minutes-select" name="minutes">
+            <option value="10">10</option>
+            <option value="15">15</option>
+            <option value="20">20</option>
+            <option value="25">25</option>
+          </select>
+        </div>
+        <div class="settings-group">
+          <label>${t('settings.language')}</label>
+          <div class="switch">
+            <span>CS</span>
+            <input type="checkbox" id="lang-toggle" ${getLang() === 'en' ? 'checked' : ''} aria-label="${t('settings.language')}" />
+            <span>EN</span>
+          </div>
+        </div>
+        <div class="settings-group">
+          <label>${t('settings.sound')}</label>
+          <div class="switch">
+            <input type="checkbox" id="sound-toggle" ${state.sound ? 'checked' : ''} aria-label="${t('settings.sound')}" />
+          </div>
+        </div>
+        <div class="settings-group">
+          <label>${t('settings.partner')}</label>
+          <div class="switch">
+            <input type="checkbox" id="partner-toggle" ${state.partnerMode ? 'checked' : ''} aria-label="${t('settings.partner')}" />
+          </div>
+        </div>
+        <div class="settings-group">
+          <label for="reminder">${t('settings.reminder')}</label>
+          <input type="time" id="reminder" value="${state.reminderTime || ''}" />
+        </div>
+        <div class="settings-group">
+          <label for="start-side">${t('settings.startSide')}</label>
+          <select id="start-side">
+            <option value="left">${t('settings.startLeft')}</option>
+            <option value="right">${t('settings.startRight')}</option>
+          </select>
+        </div>
+        <div class="settings-group">
+          <button type="button" class="btn btn--danger" id="reset-data">${t('settings.reset')}</button>
+        </div>
+      </form>
+    </section>
+  `;
+  const goal = document.getElementById('goal-select');
+  const minutes = document.getElementById('minutes-select');
+  const langToggle = document.getElementById('lang-toggle');
+  const soundToggle = document.getElementById('sound-toggle');
+  const partnerToggle = document.getElementById('partner-toggle');
+  const reminder = document.getElementById('reminder');
+  const startSide = document.getElementById('start-side');
+  goal.value = state.goal;
+  minutes.value = String(state.minutesPerDay);
+  startSide.value = state.startSide;
+
+  goal.addEventListener('change', (e) => {
+    updateState((draft) => {
+      draft.goal = e.target.value;
+      return draft;
+    });
+  });
+  minutes.addEventListener('change', (e) => {
+    updateState((draft) => {
+      draft.minutesPerDay = Number(e.target.value);
+      return draft;
+    });
+  });
+  langToggle.addEventListener('change', (e) => {
+    setLang(e.target.checked ? 'en' : 'cs');
+  });
+  soundToggle.addEventListener('change', (e) => {
+    updateState((draft) => {
+      draft.sound = e.target.checked;
+      return draft;
+    });
+  });
+  partnerToggle.addEventListener('change', (e) => {
+    updateState((draft) => {
+      draft.partnerMode = e.target.checked;
+      return draft;
+    });
+  });
+  reminder.addEventListener('change', (e) => {
+    updateState((draft) => {
+      draft.reminderTime = e.target.value;
+      return draft;
+    });
+  });
+  startSide.addEventListener('change', (e) => {
+    updateState((draft) => {
+      draft.startSide = e.target.value;
+      return draft;
+    });
+  });
+  const resetBtn = document.getElementById('reset-data');
+  resetBtn.addEventListener('click', () => {
+    const confirmed = window.confirm(t('settings.confirmReset'));
+    if (confirmed) {
+      state = cloneState(defaultState);
+      state.lang = getLang();
+      notifyState();
+      renderSettings();
+    }
+  });
+}
+
+function renderProgress() {
+  const sessions = state.logs.sessions || [];
+  if (!sessions.length) {
+    appRoot.innerHTML = `<section class="card"><h1>${t('progress.title')}</h1><p>${t('progress.empty')}</p></section>`;
+    return;
+  }
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth();
+  const firstDay = new Date(year, month, 1);
+  const totalDays = new Date(year, month + 1, 0).getDate();
+  const startOffset = (firstDay.getDay() + 6) % 7;
+  const counts = new Map();
+  for (const log of sessions) {
+    counts.set(log.date, (counts.get(log.date) || 0) + 1);
+  }
+  let calendarHtml = '';
+  for (let i = 0; i < startOffset; i += 1) {
+    calendarHtml += '<div class="calendar-cell" aria-hidden="true"></div>';
+  }
+  for (let day = 1; day <= totalDays; day += 1) {
+    const dateObj = new Date(year, month, day);
+    const key = formatDateKey(dateObj);
+    const count = counts.get(key) || 0;
+    calendarHtml += `<div class="calendar-cell" data-count="${Math.min(count, 10)}" aria-label="${key}: ${count} ${t('progress.totalSessions').toLowerCase()}">${day}</div>`;
+  }
+  const totalSessions = sessions.length;
+  const earliestDate = sessions.reduce((min, log) => (log.date < min ? log.date : min), sessions[0].date);
+  const daysActive = Math.max(1, (now - new Date(earliestDate)) / 86400000 + 1);
+  const avgPerWeek = (totalSessions / (daysActive / 7)).toFixed(1);
+
+  appRoot.innerHTML = `
+    <section class="card">
+      <h1>${t('progress.title')}</h1>
+      <h2>${t('progress.month')}</h2>
+      <div class="calendar-grid" role="grid">${calendarHtml}</div>
+      <div class="summary-grid">
+        <div class="summary-card">
+          <span>${t('progress.totalSessions')}</span>
+          <strong>${totalSessions}</strong>
+        </div>
+        <div class="summary-card">
+          <span>${t('progress.avgPerWeek')}</span>
+          <strong>${avgPerWeek}</strong>
+        </div>
+      </div>
+      <button class="btn btn--secondary" id="export-json">${t('progress.export')}</button>
+    </section>
+  `;
+  const exportBtn = document.getElementById('export-json');
+  exportBtn?.addEventListener('click', () => {
+    const blob = new Blob([JSON.stringify(state.logs, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `suzuki-stretch-logs-${formatDateKey(new Date())}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  });
+}
+
+function renderSession() {
+  if (!dataReady) {
+    appRoot.innerHTML = `<section class="card"><p>Načítání…</p></section>`;
+    return;
+  }
+  if (!sessionCtx) {
+    sessionCtx = createSessionContext();
+  }
+  const segment = sessionCtx.segments[sessionCtx.index] || null;
+  if (sessionCtx.completed) {
+    renderSessionComplete();
+    return;
+  }
+  const lang = getLang();
+  const exercise = segment?.exercise || sessionCtx.segments.find((seg) => seg.exercise)?.exercise || exercises[0];
+  const name = exercise?.name?.[lang] || '';
+  const cues = exercise?.cues?.[lang] || [];
+  const phaseLabel = segment?.kind === 'phase'
+    ? segment.phase === 'A'
+      ? t('session.phaseA')
+      : t('session.phaseB')
+    : segment?.kind === 'transition'
+    ? t('session.transition')
+    : segment?.kind === 'sideSwitch'
+    ? t('session.sideSwitch')
+    : '';
+  const sideLabel = segment?.side
+    ? segment.side === 'left'
+      ? t('session.sideLeft')
+      : t('session.sideRight')
+    : '';
+  const timerValue = formatTime(Math.max(0, Math.ceil((segment?.duration || 0) - sessionCtx.elapsed)));
+  const progress = computeProgress();
+  const nextDisabled = !segment || (segment.kind === 'phase' && segment.phase === 'A' && sessionCtx.elapsed < segment.duration);
+
+  appRoot.innerHTML = `
+    <section class="session-layout">
+      <header class="session-header">
+        <h1>${name}</h1>
+        <div class="session-progress" aria-label="progress">
+          <div class="session-progress__bar" style="width:${progress}%"></div>
+        </div>
+        <div class="timer-phase">${phaseLabel}</div>
+        ${sideLabel ? `<div class="side-indicator">${renderSideIcon(segment.side)} ${sideLabel}</div>` : ''}
+        <div class="timer-display" id="timer-display" aria-live="assertive">${timerValue}</div>
+        <div class="breath-ticker" id="breath-ticker">${t('session.breathIn')}</div>
+        ${sessionCtx.guardMessage ? `<div class="guard-message" role="alert">${sessionCtx.guardMessage}</div>` : ''}
+      </header>
+      <div class="session-card card">
+        <div class="session-card__image">
+          <img src="${exercise.image}" alt="${name}" />
+        </div>
+        <div class="session-info">
+          <span class="session-info__tag">${exercise.asym ? t('exercises.asym') : t('exercises.sym')}</span>
+          <strong>${t('session.holdLabel')}</strong>
+          <ul class="cue-list">
+            ${cues.map((cue) => `<li>${cue}</li>`).join('')}
+          </ul>
+        </div>
+      </div>
+    </section>
+    <div class="control-bar">
+      <div class="control-bar__inner">
+        <button class="btn btn--secondary" data-action="back" ${sessionCtx.index === 0 && sessionCtx.elapsed < 0.1 ? 'disabled' : ''}>${t('session.back')}</button>
+        <button class="btn" data-action="toggle">${sessionCtx.running ? t('session.pause') : t('session.start')}</button>
+        <button class="btn btn--secondary" data-action="next" ${nextDisabled ? 'disabled' : ''}>${t('session.next')}</button>
+        <button class="btn btn--secondary" data-action="reset">${t('session.reset')}</button>
+        <button class="btn btn--secondary" data-action="backoff">${t('session.backOff')}</button>
+      </div>
+    </div>
+  `;
+
+  sessionCtx.dom = {
+    timer: document.getElementById('timer-display'),
+    progress: appRoot.querySelector('.session-progress__bar'),
+    guard: appRoot.querySelector('.guard-message'),
+    breath: document.getElementById('breath-ticker')
+  };
+  bindSessionControls();
+  startBreathTicker();
+  updateSessionDom();
+}
+
+function renderSideIcon(side) {
+  if (side === 'left') {
+    return `<img src="assets/icons/left.svg" alt="" />`;
+  }
+  if (side === 'right') {
+    return `<img src="assets/icons/right.svg" alt="" />`;
+  }
+  return '';
+}
+
+function createSessionContext() {
+  const baseList = state.partnerMode ? exercises : exercises.slice(0, 24);
+  const routine = baseList.slice();
+  const startSide = state.startSide === 'right' ? 'right' : 'left';
+  const segments = [];
+  routine.forEach((exercise, idx) => {
+    if (idx > 0) {
+      segments.push({ kind: 'transition', duration: 3, exercise });
+    }
+    const sides = exercise.asym ? (startSide === 'left' ? ['left', 'right'] : ['right', 'left']) : [null];
+    sides.forEach((side, sideIndex) => {
+      segments.push({ kind: 'phase', phase: 'A', duration: 10, exercise, side });
+      segments.push({ kind: 'phase', phase: 'B', duration: 10, exercise, side });
+      if (exercise.asym && sideIndex === 0) {
+        segments.push({ kind: 'sideSwitch', duration: 3, exercise, side: sides[1] });
+      }
+    });
+  });
+  const totalDuration = segments.reduce((acc, seg) => acc + seg.duration, 0);
+  return {
+    routine,
+    segments,
+    index: 0,
+    elapsed: 0,
+    running: false,
+    guardMessage: '',
+    completed: false,
+    totalDuration,
+    startTimestamp: null,
+    notes: '',
+    saved: false
+  };
+}
+
+function bindSessionControls() {
+  const backBtn = document.querySelector('[data-action="back"]');
+  const toggleBtn = document.querySelector('[data-action="toggle"]');
+  const nextBtn = document.querySelector('[data-action="next"]');
+  const resetBtn = document.querySelector('[data-action="reset"]');
+  const backOffBtn = document.querySelector('[data-action="backoff"]');
+
+  backBtn?.addEventListener('click', handleSessionBack);
+  toggleBtn?.addEventListener('click', handleSessionToggle);
+  nextBtn?.addEventListener('click', handleSessionNext);
+  resetBtn?.addEventListener('click', handleSessionReset);
+  backOffBtn?.addEventListener('click', handleBackOff);
+}
+
+function handleSessionToggle() {
+  if (!sessionCtx) return;
+  if (sessionCtx.running) {
+    pauseTimer();
+  } else {
+    startTimer();
+  }
+  renderSession();
+}
+
+function startTimer() {
+  if (!sessionCtx) return;
+  if (!audioContext) {
+    try {
+      audioContext = new (window.AudioContext || window.webkitAudioContext)();
+    } catch (err) {
+      console.warn('Audio context unavailable', err);
+    }
+  }
+  if (audioContext && audioContext.state === 'suspended') {
+    audioContext.resume().catch(() => {});
+  }
+  if (sessionCtx.running) return;
+  sessionCtx.running = true;
+  sessionCtx.guardMessage = '';
+  if (!sessionCtx.startTimestamp) {
+    sessionCtx.startTimestamp = Date.now();
+  }
+  sessionCtx.segmentStart = performance.now() - sessionCtx.elapsed * 1000;
+  timerInterval = window.setInterval(tickSession, 50);
+}
+
+function pauseTimer() {
+  if (!sessionCtx) return;
+  sessionCtx.running = false;
+  if (timerInterval) {
+    clearInterval(timerInterval);
+    timerInterval = null;
+  }
+}
+
+function tickSession() {
+  if (!sessionCtx) return;
+  const segment = sessionCtx.segments[sessionCtx.index];
+  if (!segment) {
+    completeSession();
+    return;
+  }
+  const now = performance.now();
+  const elapsed = (now - sessionCtx.segmentStart) / 1000;
+  sessionCtx.elapsed = Math.min(segment.duration, elapsed);
+  if (sessionCtx.elapsed >= segment.duration - 0.01) {
+    sessionCtx.elapsed = segment.duration;
+    advanceSegment();
+  }
+  updateSessionDom();
+}
+
+function advanceSegment() {
+  if (!sessionCtx) return;
+  const segment = sessionCtx.segments[sessionCtx.index];
+  if (!segment) return;
+  sessionCtx.index += 1;
+  sessionCtx.elapsed = 0;
+  sessionCtx.segmentStart = performance.now();
+  if (sessionCtx.index >= sessionCtx.segments.length) {
+    completeSession();
+    return;
+  }
+  playBeep();
+  renderSession();
+}
+
+function handleSessionNext() {
+  if (!sessionCtx) return;
+  const segment = sessionCtx.segments[sessionCtx.index];
+  if (!segment) return;
+  if (segment.kind === 'phase' && segment.phase === 'A' && sessionCtx.elapsed < segment.duration) {
+    sessionCtx.guardMessage = t('session.guardPhaseA');
+    renderSession();
+    return;
+  }
+  if (segment.kind === 'phase' && segment.phase === 'B' && sessionCtx.elapsed < 5) {
+    sessionCtx.guardMessage = t('session.guardPhaseB');
+    renderSession();
+    return;
+  }
+  sessionCtx.guardMessage = '';
+  sessionCtx.segmentStart = performance.now();
+  sessionCtx.elapsed = 0;
+  sessionCtx.index = Math.min(sessionCtx.segments.length, sessionCtx.index + 1);
+  if (sessionCtx.index >= sessionCtx.segments.length) {
+    completeSession();
+    return;
+  }
+  playBeep();
+  renderSession();
+}
+
+function handleSessionBack() {
+  if (!sessionCtx) return;
+  if (sessionCtx.index === 0 && sessionCtx.elapsed < 0.1) return;
+  sessionCtx.guardMessage = '';
+  if (sessionCtx.elapsed > 1) {
+    sessionCtx.elapsed = 0;
+    sessionCtx.segmentStart = performance.now();
+  } else {
+    sessionCtx.index = Math.max(0, sessionCtx.index - 1);
+    sessionCtx.elapsed = 0;
+    sessionCtx.segmentStart = performance.now();
+  }
+  renderSession();
+}
+
+function handleSessionReset() {
+  pauseTimer();
+  sessionCtx = createSessionContext();
+  renderSession();
+}
+
+function handleBackOff() {
+  if (!sessionCtx) return;
+  pauseTimer();
+  const segment = sessionCtx.segments[sessionCtx.index];
+  if (segment?.exercise) {
+    updateState((draft) => {
+      draft.logs.backOff.push({ exerciseId: segment.exercise.id, timestamp: new Date().toISOString() });
+      return draft;
+    });
+  }
+  openModal({
+    title: t('session.backOff'),
+    body: `<p>${t('general.discomfortWarning')}</p>`,
+    actions: [
+      {
+        label: t('general.close'),
+        handler: closeModal
+      }
+    ]
+  });
+}
+
+function updateSessionDom() {
+  if (!sessionCtx?.dom) return;
+  const segment = sessionCtx.segments[sessionCtx.index];
+  if (!segment) return;
+  const remaining = Math.max(0, Math.ceil((segment.duration - sessionCtx.elapsed)));
+  sessionCtx.dom.timer.textContent = formatTime(remaining);
+  const progress = computeProgress();
+  sessionCtx.dom.progress.style.width = `${progress}%`;
+  if (sessionCtx.guardMessage && sessionCtx.dom.guard) {
+    sessionCtx.dom.guard.textContent = sessionCtx.guardMessage;
+  }
+}
+
+function computeProgress() {
+  if (!sessionCtx) return 0;
+  const completed = sessionCtx.segments.slice(0, sessionCtx.index).reduce((acc, seg) => acc + seg.duration, 0);
+  const current = sessionCtx.segments[sessionCtx.index];
+  const elapsed = current ? Math.min(current.duration, sessionCtx.elapsed) : 0;
+  const total = sessionCtx.totalDuration || 1;
+  return Math.min(100, Math.round(((completed + elapsed) / total) * 100));
+}
+
+function startBreathTicker() {
+  if (breathInterval) clearInterval(breathInterval);
+  if (!sessionCtx?.dom?.breath) return;
+  let state = 'in';
+  sessionCtx.dom.breath.textContent = t('session.breathIn');
+  breathInterval = setInterval(() => {
+    state = state === 'in' ? 'out' : 'in';
+    if (sessionCtx?.dom?.breath) {
+      sessionCtx.dom.breath.textContent = state === 'in' ? t('session.breathIn') : t('session.breathOut');
+    }
+  }, 4000);
+}
+
+function completeSession() {
+  pauseTimer();
+  if (!sessionCtx) return;
+  sessionCtx.completed = true;
+  sessionCtx.guardMessage = '';
+  if (breathInterval) {
+    clearInterval(breathInterval);
+    breathInterval = null;
+  }
+  renderSessionComplete();
+}
+
+function renderSessionComplete() {
+  const notesValue = sessionCtx.notes || '';
+  appRoot.innerHTML = `
+    <section class="card session-done">
+      <h1>${t('session.completed')}</h1>
+      <p>${t('session.notesPlaceholder')}</p>
+      <textarea id="session-notes" placeholder="${t('session.notesPlaceholder')}">${notesValue}</textarea>
+      <button class="btn" id="save-notes">${sessionCtx.saved ? t('general.close') : t('session.saveNotes')}</button>
+      <button class="btn btn--secondary" id="back-home">${t('nav.home')}</button>
+    </section>
+  `;
+  const notes = document.getElementById('session-notes');
+  notes?.addEventListener('input', (e) => {
+    sessionCtx.notes = e.target.value;
+  });
+  const save = document.getElementById('save-notes');
+  save?.addEventListener('click', () => {
+    if (!sessionCtx.saved) {
+      addSessionLog(sessionCtx.notes || '');
+      sessionCtx.saved = true;
+      save.textContent = t('general.close');
+    } else {
+      navigate('/');
+    }
+  });
+  const backHome = document.getElementById('back-home');
+  backHome?.addEventListener('click', () => navigate('/'));
+}
+
+function addSessionLog(notes) {
+  const now = new Date();
+  const dateKey = formatDateKey(now);
+  const log = {
+    id: `session-${now.getTime()}`,
+    date: dateKey,
+    timestamp: now.toISOString(),
+    duration: sessionCtx.totalDuration,
+    notes,
+    goal: state.goal,
+    partnerMode: state.partnerMode,
+    exercises: sessionCtx.routine.map((ex) => ex.id)
+  };
+  updateState((draft) => {
+    draft.logs.sessions.push(log);
+    return draft;
+  });
+}
+
+function teardownSession() {
+  pauseTimer();
+  if (breathInterval) {
+    clearInterval(breathInterval);
+    breathInterval = null;
+  }
+  sessionCtx = null;
+}
+
+function openModal({ title, body, actions = [] }) {
+  closeModal();
+  const overlay = document.createElement('div');
+  overlay.className = 'modal-overlay';
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
+  const modal = document.createElement('div');
+  modal.className = 'modal';
+  modal.setAttribute('tabindex', '-1');
+  modal.innerHTML = `
+    <header>
+      <h2>${title}</h2>
+      <button class="btn btn--ghost" data-close>${t('general.close')}</button>
+    </header>
+    <div class="modal__body">${body}</div>
+    <footer style="margin-top:1.25rem;display:flex;gap:0.75rem;flex-wrap:wrap;">
+      ${actions
+        .map(
+          (action, index) =>
+            `<button class="btn ${action.variant === 'primary' ? '' : 'btn--secondary'}" data-action="modal-${index}">${action.label}</button>`
+        )
+        .join('')}
+    </footer>
+  `;
+  overlay.appendChild(modal);
+  modalRoot.appendChild(overlay);
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) closeModal();
+  });
+  modal.querySelector('[data-close]')?.addEventListener('click', closeModal);
+  actions.forEach((action, index) => {
+    modal
+      .querySelector(`[data-action="modal-${index}"]`)
+      ?.addEventListener('click', () => {
+        if (action.handler) action.handler();
+        if (!action.keepOpen) closeModal();
+      });
+  });
+  modal.focus();
+}
+
+function closeModal() {
+  modalRoot.innerHTML = '';
+}
+
+function openRulesModal() {
+  const lang = getLang();
+  const list = document.createElement('ol');
+  rules.forEach((rule) => {
+    const item = document.createElement('li');
+    item.innerHTML = `<span>${rule.cs}</span><small>${rule.en}</small>`;
+    list.appendChild(item);
+  });
+  openModal({
+    title: t('home.rules'),
+    body: list.outerHTML,
+    actions: []
+  });
+}
+
+function playBeep() {
+  if (!state.sound || !audioContext) return;
+  const now = audioContext.currentTime;
+  const oscillator = audioContext.createOscillator();
+  const gain = audioContext.createGain();
+  oscillator.type = 'sine';
+  oscillator.frequency.setValueAtTime(880, now);
+  gain.gain.setValueAtTime(0.0001, now);
+  gain.gain.exponentialRampToValueAtTime(0.08, now + 0.01);
+  gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.2);
+  oscillator.connect(gain);
+  gain.connect(audioContext.destination);
+  oscillator.start(now);
+  oscillator.stop(now + 0.25);
+}
+
+function formatTime(value) {
+  const minutes = Math.floor(value / 60);
+  const seconds = Math.floor(Math.max(0, value % 60));
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
+
+function formatDateKey(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('./sw.js').catch((err) => console.warn('SW registration failed', err));
+  });
+}

--- a/assets/Suzukiho-strecink.pdf
+++ b/assets/Suzukiho-strecink.pdf
@@ -1,0 +1,2 @@
+This placeholder file is intentionally plain text so the repository contains no binary assets.
+Please replace it with the authentic "Suzukiho strečink" PDF before deploying the site so the download link works correctly.

--- a/assets/exercises/placeholder.svg
+++ b/assets/exercises/placeholder.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
+  <title id="title">Silhouette Stretch Placeholder</title>
+  <desc id="desc">Minimalist outline of a person stretching</desc>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1f7a8c" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#4ac6e9" stop-opacity="0.9" />
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="112" height="112" rx="18" ry="18" fill="none" stroke="url(#grad)" stroke-width="4" />
+  <path d="M40 90c8-16 12-24 24-24s16 8 24 24" fill="none" stroke="url(#grad)" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="64" cy="42" r="12" fill="url(#grad)" />
+  <path d="M64 54c-8 12-18 22-30 28" fill="none" stroke="url(#grad)" stroke-width="6" stroke-linecap="round" />
+  <path d="M64 54c8 12 18 22 30 28" fill="none" stroke="url(#grad)" stroke-width="6" stroke-linecap="round" />
+</svg>

--- a/assets/icons/back.svg
+++ b/assets/icons/back.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="15 5 8 12 15 19"></polyline>
+  <line x1="8" y1="12" x2="20" y2="12"></line>
+</svg>

--- a/assets/icons/left.svg
+++ b/assets/icons/left.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="9"></circle>
+  <polyline points="13 8 9 12 13 16"></polyline>
+</svg>

--- a/assets/icons/next.svg
+++ b/assets/icons/next.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="9 5 16 12 9 19"></polyline>
+  <line x1="4" y1="12" x2="16" y2="12"></line>
+</svg>

--- a/assets/icons/pause.svg
+++ b/assets/icons/pause.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="7" y="4" width="4" height="16" fill="currentColor" stroke="none"></rect>
+  <rect x="13" y="4" width="4" height="16" fill="currentColor" stroke="none"></rect>
+</svg>

--- a/assets/icons/play.svg
+++ b/assets/icons/play.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polygon points="7,4 19,12 7,20" fill="currentColor" stroke="none"></polygon>
+</svg>

--- a/assets/icons/right.svg
+++ b/assets/icons/right.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="9"></circle>
+  <polyline points="11 8 15 12 11 16"></polyline>
+</svg>

--- a/data/exercises.json
+++ b/data/exercises.json
@@ -1,0 +1,352 @@
+[
+  {
+    "id": "deep-squat-groin",
+    "name": { "cs": "Hluboký dřep - kyčle", "en": "Deep Squat Groin" },
+    "asym": false,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Kolena tlačit ven", "Páteř dlouhá, hrudník otevřený", "Fáze A držet 10 s", "Fáze B mírně prohloubit"],
+      "en": ["Press knees outward", "Keep spine long and chest open", "Hold phase A for 10 s", "Deepen gently in phase B"]
+    }
+  },
+  {
+    "id": "seated-straddle-prep",
+    "name": { "cs": "Sed široký - příprava", "en": "Seated Straddle Prep" },
+    "asym": false,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Sedět na sedacích kostech", "Chodidla flexovat", "Aktivní střed těla", "Nádech nahoru, výdech do předklonu"],
+      "en": ["Sit on sit bones", "Flex the feet", "Engage the core", "Inhale tall, exhale to hinge"]
+    }
+  },
+  {
+    "id": "standing-hamstring-soft-knee",
+    "name": { "cs": "Stoj předklon - měkká kolena", "en": "Standing Hamstring Soft Knee" },
+    "asym": true,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Zadní noha lehce pokrčená", "Pánev neutrální", "Fáze A jemný tah", "Fáze B přiblížit hrudník"],
+      "en": ["Back knee softly bent", "Keep pelvis neutral", "Phase A gentle traction", "Phase B draw chest closer"]
+    }
+  },
+  {
+    "id": "runners-lunge-knee-up",
+    "name": { "cs": "Výpad běžce - koleno nahoře", "en": "Runner's Lunge Knee Up" },
+    "asym": true,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Koleno nad kotníkem", "Zadní noha dlouhá", "Tlačit kyčel k podlaze", "Výdech prohloubení"],
+      "en": ["Front knee over ankle", "Back leg long", "Sink hip toward floor", "Exhale to deepen"]
+    }
+  },
+  {
+    "id": "wide-knee-squat",
+    "name": { "cs": "Široký dřep s koleny ven", "en": "Wide Knee Squat" },
+    "asym": false,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Kolena ven a dolů", "Lokty tlačí stehna", "Fáze A prodýchat", "Fáze B přitáhnout pánev"],
+      "en": ["Knees move outward", "Elbows press thighs", "Breathe through phase A", "Pull pelvis closer in phase B"]
+    }
+  },
+  {
+    "id": "supine-single-leg-hamstring",
+    "name": { "cs": "Leh - hamstring jedna noha", "en": "Supine Single-Leg Hamstring" },
+    "asym": true,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Pánev na zemi", "Kotník flex", "Držet stehno ve stejné linii", "Přitáhnout jen do příjemného tahu"],
+      "en": ["Pelvis grounded", "Flex the ankle", "Keep thigh in line", "Only to a pleasant stretch"]
+    }
+  },
+  {
+    "id": "supine-middle-split",
+    "name": { "cs": "Leh - středový rozštěp", "en": "Supine Middle Split" },
+    "asym": false,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Bedra přilepená", "Chodidla flex", "Kolena natažená", "Dech do třísel"],
+      "en": ["Lower back grounded", "Flex feet", "Knees straight", "Breathe into groin"]
+    }
+  },
+  {
+    "id": "supine-hip-external-rotation",
+    "name": { "cs": "Leh - vnější rotace kyčle", "en": "Supine Hip External Rotation" },
+    "asym": true,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Kotník přes koleno", "Bedra těžká", "Koleno směrem od těla", "Fáze B jemně přitlačit"],
+      "en": ["Ankle crosses knee", "Heavy through low back", "Knee moves away", "Press gently in phase B"]
+    }
+  },
+  {
+    "id": "butterfly",
+    "name": { "cs": "Motýlek", "en": "Butterfly" },
+    "asym": false,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Chodidla spojit", "Kolena k zemi", "Páteř vzpřímená", "Lokty nechte uvolněné"],
+      "en": ["Bring soles together", "Knees toward floor", "Spine upright", "Relax the elbows"]
+    }
+  },
+  {
+    "id": "seated-single-leg-forward-fold",
+    "name": { "cs": "Sed - předklon k jedné noze", "en": "Seated Single-Leg Forward Fold" },
+    "asym": true,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Sedací kosti v zemi", "Vytáhnout se do dálky", "Fáze A hrudník k stehnu", "Fáze B přitáhnout chodidlo"],
+      "en": ["Ground the sit bones", "Reach long through spine", "Phase A chest to thigh", "Phase B draw foot closer"]
+    }
+  },
+  {
+    "id": "seated-pancake-fold",
+    "name": { "cs": "Sed - pancake předklon", "en": "Seated Pancake Fold" },
+    "asym": false,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Kolena natažená", "Pánev vpřed", "Fáze A ruce na podložce", "Fáze B posunout dlaně dál"],
+      "en": ["Legs straight", "Tilt pelvis forward", "Phase A hands on floor", "Phase B walk hands forward"]
+    }
+  },
+  {
+    "id": "half-middle-split-side-fold",
+    "name": { "cs": "Půlka střihu - boční předklon", "en": "Half Middle Split Side Fold" },
+    "asym": true,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Koleno spodní nohy pod kyčel", "Horní noha natažená", "Fáze A opora o předloktí", "Fáze B přiblížit trup"],
+      "en": ["Bottom knee under hip", "Top leg long", "Phase A support on forearm", "Phase B draw torso closer"]
+    }
+  },
+  {
+    "id": "seated-spinal-twist",
+    "name": { "cs": "Sed - rotační twist", "en": "Seated Spinal Twist" },
+    "asym": true,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Sed vysoký", "Otočit od pasu", "Ramena dolů", "Fáze B pohled přes rameno"],
+      "en": ["Sit tall", "Rotate from waist", "Shoulders down", "Phase B gaze past shoulder"]
+    }
+  },
+  {
+    "id": "kneeling-quad-hip-flexor",
+    "name": { "cs": "Klek - stehenní a kyčelní flexor", "en": "Kneeling Quad Hip Flexor" },
+    "asym": true,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Pánev podsadit", "Žebra dolů", "Tlačit kyčel vpřed", "Fáze B přidat náklon"],
+      "en": ["Posterior tilt pelvis", "Drop ribs down", "Drive hip forward", "Phase B add gentle lean"]
+    }
+  },
+  {
+    "id": "bridge-prep-table",
+    "name": { "cs": "Most - příprava stolek", "en": "Bridge Prep Table" },
+    "asym": false,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Dlaně pod rameny", "Aktivní lopatky", "Hrudník vzhůru", "Hlava neutrálně"],
+      "en": ["Hands under shoulders", "Activate shoulder blades", "Lift chest up", "Head neutral"]
+    }
+  },
+  {
+    "id": "full-bridge-wheel",
+    "name": { "cs": "Plný most - kolo", "en": "Full Bridge Wheel" },
+    "asym": false,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Dlaně otáčet k nohám", "Tlačit přes stehna", "Fáze A uvolnit ramena", "Fáze B otevřít hrudník"],
+      "en": ["Rotate palms toward feet", "Drive through thighs", "Phase A relax shoulders", "Phase B open chest"]
+    }
+  },
+  {
+    "id": "hollow-boat-tuck",
+    "name": { "cs": "Dutá loďka - skrčení", "en": "Hollow Boat Tuck" },
+    "asym": false,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Bedra přilepit", "Žebra dovnitř", "Kolena v pravém úhlu", "Dýchat do břicha"],
+      "en": ["Press low back down", "Ribs knit in", "Knees at right angle", "Breathe into belly"]
+    }
+  },
+  {
+    "id": "tuck-support-lsit-prep",
+    "name": { "cs": "Opora ve skrčení - příprava L-sit", "en": "Tuck Support L-Sit Prep" },
+    "asym": false,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Dlaně pevně v zemi", "Ramena od uší", "Kolena k hrudníku", "Fáze B protáhnout sedací kosti"],
+      "en": ["Hands press firmly", "Shoulders away from ears", "Knees toward chest", "Phase B lengthen sit bones"]
+    }
+  },
+  {
+    "id": "crow-prep",
+    "name": { "cs": "Vrána - příprava", "en": "Crow Prep" },
+    "asym": false,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Kolena na tricepsy", "Pohled vpřed", "Aktivní prsty", "Fáze B odlehčit chodidla"],
+      "en": ["Knees hug triceps", "Gaze forward", "Active fingers", "Phase B lighten the feet"]
+    }
+  },
+  {
+    "id": "low-straddle-lean",
+    "name": { "cs": "Nízký rozštěp - náklon", "en": "Low Straddle Lean" },
+    "asym": false,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Kolena a prsty vpřed", "Pánev nízko", "Fáze A jemný tlak", "Fáze B otevřít kyčle"],
+      "en": ["Knees and toes forward", "Keep hips low", "Phase A gentle pressure", "Phase B open hips"]
+    }
+  },
+  {
+    "id": "front-split-prep",
+    "name": { "cs": "Provaz - příprava", "en": "Front Split Prep" },
+    "asym": true,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Pánev čelem vpřed", "Zadní noha aktivní", "Fáze A ruce na podložce", "Fáze B posunout bloky"],
+      "en": ["Square the hips", "Back leg engaged", "Phase A hands on floor", "Phase B adjust blocks"]
+    }
+  },
+  {
+    "id": "front-split",
+    "name": { "cs": "Provaz (přední)", "en": "Front Split" },
+    "asym": true,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Jít pomalu", "Fáze A držet 10 s", "Fáze B prohloubit dech", "Bez kmitání"],
+      "en": ["Enter slowly", "Hold 10 s in phase A", "Phase B deepen with breath", "No bouncing"]
+    }
+  },
+  {
+    "id": "middle-split",
+    "name": { "cs": "Provaz střední", "en": "Middle Split" },
+    "asym": false,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Pánev neutrální", "Kolena vzhůru", "Fáze A podpírat rukama", "Fáze B klesnout níž"],
+      "en": ["Pelvis neutral", "Knees face up", "Support with hands in phase A", "Lower gently in phase B"]
+    }
+  },
+  {
+    "id": "seated-wide-straddle-fold",
+    "name": { "cs": "Sed - široký předklon", "en": "Seated Wide Straddle Fold" },
+    "asym": false,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Chodidla flex", "Páteř rovná", "Fáze A dlaně na zemi", "Fáze B hrudník níž"],
+      "en": ["Flex the feet", "Keep spine long", "Hands down in phase A", "Phase B chest lower"]
+    }
+  },
+  {
+    "id": "partner-hip-external-rotation",
+    "name": { "cs": "Partner - vnější rotace kyčle", "en": "Partner Hip External Rotation" },
+    "asym": true,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Komunikovat rozsah", "Partner tlačí plynule", "Fáze A dech klidný", "Fáze B malé prohloubení"],
+      "en": ["Communicate range", "Partner applies smooth pressure", "Steady breathing in phase A", "Small deepen in phase B"]
+    }
+  },
+  {
+    "id": "partner-assisted-hamstring",
+    "name": { "cs": "Partner - hamstring", "en": "Partner Assisted Hamstring" },
+    "asym": true,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Koleno natažené", "Partner drží patu", "Zastavit při diskomfortu", "Výdech prohloubení"],
+      "en": ["Keep knee straight", "Partner supports heel", "Stop at discomfort", "Exhale to deepen"]
+    }
+  },
+  {
+    "id": "partner-assisted-pike",
+    "name": { "cs": "Partner - předklon", "en": "Partner Assisted Pike" },
+    "asym": false,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Pánev nad patami", "Partner tlačí bedra", "Fáze A stabilizovat", "Fáze B malý tlak"],
+      "en": ["Hips over heels", "Partner guides lower back", "Stabilise in phase A", "Phase B gentle pressure"]
+    }
+  },
+  {
+    "id": "partner-side-lying-quad",
+    "name": { "cs": "Partner - ležící kvadriceps", "en": "Partner Side-Lying Quad" },
+    "asym": true,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Koleno v jedné linii", "Partner drží kyčel", "Fáze A otevřít stehno", "Fáze B přitáhnout patu"],
+      "en": ["Knee in one line", "Partner stabilises hip", "Open thigh in phase A", "Phase B draw heel closer"]
+    }
+  },
+  {
+    "id": "partner-standing-pec-shoulder",
+    "name": { "cs": "Partner - hrudník a rameno", "en": "Partner Standing Pec Shoulder" },
+    "asym": false,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Prsty propletené", "Otevřít hrudník", "Partner opatrně tlačí", "Dýchat do horní části"],
+      "en": ["Interlace fingers", "Open the chest", "Partner presses carefully", "Breathe into upper body"]
+    }
+  },
+  {
+    "id": "partner-assisted-side-lunge",
+    "name": { "cs": "Partner - boční výpad", "en": "Partner Assisted Side Lunge" },
+    "asym": true,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Chodidlo celé na zemi", "Partner podpírá trup", "Fáze A stabilně", "Fáze B prohloubit posun"],
+      "en": ["Foot fully planted", "Partner supports torso", "Stay stable in phase A", "Phase B deepen shift"]
+    }
+  },
+  {
+    "id": "partner-assisted-front-split-press",
+    "name": { "cs": "Partner - tlak do provazu", "en": "Partner Assisted Front Split Press" },
+    "asym": true,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Komunikovat tlak", "Partner tlačí na pánev", "Fáze A držet nastavení", "Fáze B lehké prohloubení"],
+      "en": ["Communicate pressure", "Partner presses at pelvis", "Hold alignment in phase A", "Slight deepen in phase B"]
+    }
+  },
+  {
+    "id": "partner-assisted-hip-flexor-quad",
+    "name": { "cs": "Partner - kyčelní flexor a kvadriceps", "en": "Partner Assisted Hip Flexor Quad" },
+    "asym": true,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Koleno chránit podložkou", "Partner podpírá trup", "Fáze A dýchat do stehna", "Fáze B posunout pánev"],
+      "en": ["Pad under knee", "Partner supports torso", "Breathe into thigh", "Phase B move hips forward"]
+    }
+  },
+  {
+    "id": "partner-assisted-overhead-shoulder-flexion",
+    "name": { "cs": "Partner - protažení nad hlavou", "en": "Partner Assisted Overhead Shoulder Flexion" },
+    "asym": false,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Břicho aktivní", "Partner drží za zápěstí", "Fáze A otevřít ramena", "Fáze B lehký tlak dozadu"],
+      "en": ["Engage the core", "Partner holds wrists", "Open shoulders in phase A", "Phase B gentle push back"]
+    }
+  },
+  {
+    "id": "partner-assisted-standing-hamstring-lift",
+    "name": { "cs": "Partner - zvednutý hamstring", "en": "Partner Assisted Standing Hamstring Lift" },
+    "asym": true,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Stojná noha pevná", "Partner podpírá patu", "Fáze A jen lehký tlak", "Fáze B přiblížit stehno"],
+      "en": ["Standing leg steady", "Partner supports heel", "Light pressure in phase A", "Phase B bring thigh closer"]
+    }
+  },
+  {
+    "id": "partner-assisted-standing-front-split-lift",
+    "name": { "cs": "Partner - zvedaný provaz", "en": "Partner Assisted Standing Front Split Lift" },
+    "asym": true,
+    "image": "assets/exercises/placeholder.svg",
+    "cues": {
+      "cs": ["Střed těla aktivní", "Partner vede nohu", "Fáze A vyrovnat pánev", "Fáze B zvednout jen do komfortu"],
+      "en": ["Engage the core", "Partner guides the leg", "Level hips in phase A", "Phase B lift only to comfort"]
+    }
+  }
+]

--- a/i18n.js
+++ b/i18n.js
@@ -1,0 +1,262 @@
+const LANG_KEY = 'ssc-lang';
+const supported = ['cs', 'en'];
+const listeners = new Set();
+
+const translations = {
+  cs: {
+    nav: {
+      home: 'Domů',
+      session: 'Session',
+      exercises: 'Cviky',
+      settings: 'Nastavení',
+      progress: 'Pokrok'
+    },
+    home: {
+      title: 'Denní rutina Suzukiho strečinku',
+      start: 'Start dnešní strečink',
+      streak: 'Posledních 7 dní',
+      rules: 'Pravidla / Rules',
+      openPdf: 'Otevřít PDF',
+      reminder: 'Připomínka',
+      noReminder: 'Připomínka není nastavena',
+      todayReminder: 'Dnes v {time}'
+    },
+    session: {
+      heading: 'Session',
+      transition: 'Připravit se',
+      sideSwitch: 'Vyměň stranu',
+      phaseA: 'Fáze A',
+      phaseB: 'Fáze B',
+      phaseShortA: 'A',
+      phaseShortB: 'B',
+      sideLeft: 'Levý bok',
+      sideRight: 'Pravý bok',
+      breathIn: 'Nádech',
+      breathOut: 'Výdech',
+      start: 'Start',
+      pause: 'Pauza',
+      reset: 'Reset',
+      back: 'Zpět',
+      next: 'Další',
+      backOff: 'Back off',
+      guardPhaseA: 'Dokončete nejprve fázi A.',
+      guardPhaseB: 'Nechte tělo alespoň 5 sekund ve fázi B.',
+      holdLabel: 'Držet',
+      completed: 'Hotovo!',
+      saveNotes: 'Uložit poznámky',
+      notesPlaceholder: 'Co bylo dnes ztuhlé?'
+    },
+    exercises: {
+      title: 'Seznam cviků',
+      asym: 'Asymetrické',
+      sym: 'Symetrické',
+      cues: 'Tipy'
+    },
+    settings: {
+      title: 'Nastavení',
+      goalLabel: 'Cíl',
+      goalMobility: 'Obecná mobilita',
+      goalBridge: 'Most',
+      goalSplit: 'Provaz',
+      minutes: 'Minuty denně',
+      language: 'Jazyk',
+      sound: 'Zvukové upozornění',
+      partner: 'Partner režim (cviky 25–35)',
+      reminder: 'Čas připomínky',
+      reset: 'Resetovat všechna data',
+      confirmReset: 'Opravdu vymazat všechna data?',
+      startSide: 'Začínat stranou',
+      startLeft: 'Levou',
+      startRight: 'Pravou',
+      saved: 'Nastavení uloženo'
+    },
+    progress: {
+      title: 'Pokrok',
+      month: 'Měsíční kalendář',
+      totalSessions: 'Počet session',
+      avgPerWeek: 'Průměr týdně',
+      export: 'Exportovat JSON',
+      empty: 'Žádné záznamy zatím'
+    },
+    general: {
+      close: 'Zavřít',
+      cancel: 'Zrušit',
+      confirm: 'Potvrdit',
+      pdfAlt: 'Odkaz na PDF',
+      download: 'Stáhnout',
+      today: 'Dnes',
+      upcoming: 'Další',
+      discomfortWarning: 'Zastavte cvičení, uvolněte se, a pokud bolest přetrvává, vynechte dnešní cvičení.'
+    }
+  },
+  en: {
+    nav: {
+      home: 'Home',
+      session: 'Session',
+      exercises: 'Exercises',
+      settings: 'Settings',
+      progress: 'Progress'
+    },
+    home: {
+      title: 'Daily Suzuki Stretching Routine',
+      start: 'Start today\'s stretch',
+      streak: 'Last 7 days',
+      rules: 'Rules',
+      openPdf: 'Open PDF',
+      reminder: 'Reminder',
+      noReminder: 'Reminder not set',
+      todayReminder: 'Today at {time}'
+    },
+    session: {
+      heading: 'Session',
+      transition: 'Get Ready',
+      sideSwitch: 'Switch side',
+      phaseA: 'Phase A',
+      phaseB: 'Phase B',
+      phaseShortA: 'A',
+      phaseShortB: 'B',
+      sideLeft: 'Left side',
+      sideRight: 'Right side',
+      breathIn: 'Inhale',
+      breathOut: 'Exhale',
+      start: 'Start',
+      pause: 'Pause',
+      reset: 'Reset',
+      back: 'Back',
+      next: 'Next',
+      backOff: 'Back off',
+      guardPhaseA: 'Complete phase A first.',
+      guardPhaseB: 'Stay at least 5 seconds in phase B.',
+      holdLabel: 'Hold',
+      completed: 'Session complete!',
+      saveNotes: 'Save notes',
+      notesPlaceholder: 'What felt stiff today?'
+    },
+    exercises: {
+      title: 'Exercise list',
+      asym: 'Asymmetrical',
+      sym: 'Symmetrical',
+      cues: 'Cues'
+    },
+    settings: {
+      title: 'Settings',
+      goalLabel: 'Goal',
+      goalMobility: 'General mobility',
+      goalBridge: 'Bridge',
+      goalSplit: 'Front split',
+      minutes: 'Minutes per day',
+      language: 'Language',
+      sound: 'Sound cue',
+      partner: 'Partner mode (exercises 25–35)',
+      reminder: 'Reminder time',
+      reset: 'Reset all data',
+      confirmReset: 'Reset everything?',
+      startSide: 'Start on side',
+      startLeft: 'Left',
+      startRight: 'Right',
+      saved: 'Settings saved'
+    },
+    progress: {
+      title: 'Progress',
+      month: 'Monthly calendar',
+      totalSessions: 'Sessions',
+      avgPerWeek: 'Average per week',
+      export: 'Export JSON',
+      empty: 'No records yet'
+    },
+    general: {
+      close: 'Close',
+      cancel: 'Cancel',
+      confirm: 'Confirm',
+      pdfAlt: 'PDF link',
+      download: 'Download',
+      today: 'Today',
+      upcoming: 'Next',
+      discomfortWarning: 'Stop exercising, relax, and if the pain persists skip today\'s practice.'
+    }
+  }
+};
+
+let currentLang = (() => {
+  const stored = localStorage.getItem(LANG_KEY);
+  if (stored && supported.includes(stored)) return stored;
+  return 'cs';
+})();
+
+document.documentElement.lang = currentLang;
+
+toggleHtmlLang(currentLang);
+
+function toggleHtmlLang(lang) {
+  document.documentElement.lang = lang;
+  document.documentElement.setAttribute('data-lang', lang);
+}
+
+export function initI18n() {
+  toggleHtmlLang(currentLang);
+}
+
+export function getLang() {
+  return currentLang;
+}
+
+export function setLang(lang) {
+  if (!supported.includes(lang)) lang = 'cs';
+  currentLang = lang;
+  localStorage.setItem(LANG_KEY, lang);
+  toggleHtmlLang(lang);
+  listeners.forEach((fn) => fn(lang));
+}
+
+export function onLangChange(fn) {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+export function t(path, vars = {}) {
+  const langDict = translations[currentLang] || translations.cs;
+  const segments = path.split('.');
+  let node = langDict;
+  for (const segment of segments) {
+    if (node && Object.prototype.hasOwnProperty.call(node, segment)) {
+      node = node[segment];
+    } else {
+      node = null;
+      break;
+    }
+  }
+  if (typeof node === 'string') {
+    return formatString(node, vars);
+  }
+  if (node == null) {
+    const fallback = getFallback(path);
+    return formatString(fallback, vars);
+  }
+  return node;
+}
+
+function getFallback(path) {
+  const segments = path.split('.');
+  let node = translations.en;
+  for (const segment of segments) {
+    if (node && Object.prototype.hasOwnProperty.call(node, segment)) {
+      node = node[segment];
+    } else {
+      return path;
+    }
+  }
+  return typeof node === 'string' ? node : path;
+}
+
+function formatString(str, vars) {
+  return str.replace(/\{(.*?)\}/g, (_, key) => {
+    if (Object.prototype.hasOwnProperty.call(vars, key)) {
+      return vars[key];
+    }
+    return `{${key}}`;
+  });
+}
+
+export function getTranslations() {
+  return translations[currentLang] || translations.cs;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="cs">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Suzuki Stretch Coach</title>
+    <meta name="description" content="Časovačem vedená rutina Suzukiho strečinku." />
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="icon" href="assets/icons/play.svg" type="image/svg+xml" />
+  </head>
+  <body>
+    <header class="top-bar" role="banner">
+      <div class="top-bar__inner">
+        <a class="brand" href="#/">Suzuki Stretch Coach</a>
+        <nav aria-label="Hlavní navigace" class="nav">
+          <a href="#/" data-route="/">Domů</a>
+          <a href="#/session" data-route="/session">Session</a>
+          <a href="#/exercises" data-route="/exercises">Cviky</a>
+          <a href="#/settings" data-route="/settings">Nastavení</a>
+          <a href="#/progress" data-route="/progress">Pokrok</a>
+        </nav>
+      </div>
+    </header>
+    <main id="app" tabindex="-1"></main>
+    <div id="modal-root" aria-live="polite"></div>
+    <noscript>
+      <p class="noscript">Tato aplikace potřebuje JavaScript. Prosím, povolte jej.</p>
+    </noscript>
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/router.js
+++ b/router.js
@@ -1,0 +1,40 @@
+const defaultRoute = '/';
+let currentRoute = defaultRoute;
+let renderFn = () => {};
+
+function normalize(hash) {
+  if (!hash || hash === '#') return defaultRoute;
+  const value = hash.startsWith('#') ? hash.slice(1) : hash;
+  return value || defaultRoute;
+}
+
+export function initRouter(render) {
+  renderFn = render;
+  window.addEventListener('hashchange', handleChange);
+  if (!window.location.hash) {
+    window.location.hash = defaultRoute;
+  } else {
+    handleChange();
+  }
+}
+
+function handleChange() {
+  const path = normalize(window.location.hash);
+  currentRoute = path;
+  renderFn(path);
+  window.requestAnimationFrame(() => {
+    window.scrollTo({ top: 0, behavior: 'instant' in window ? 'instant' : 'auto' });
+  });
+}
+
+export function getCurrentRoute() {
+  return currentRoute;
+}
+
+export function navigate(path) {
+  if (!path.startsWith('#')) {
+    window.location.hash = `#${path}`;
+  } else {
+    window.location.hash = path;
+  }
+}

--- a/src/rules.js
+++ b/src/rules.js
@@ -1,0 +1,42 @@
+export const rules = [
+  {
+    cs: 'Před strečinkem se vždy rozehřejte; studené svaly nestlačujte do krajních poloh.',
+    en: 'Always warm up first; never force cold muscles into end ranges.'
+  },
+  {
+    cs: 'Dodržujte pořadí pozic tak, jak jsou v sešitu za sebou.',
+    en: 'Follow the order of the illustrated positions.'
+  },
+  {
+    cs: 'Do pozice vstupujte i vystupujte pomalu, bez trhání.',
+    en: 'Enter and exit each position slowly without jerking.'
+  },
+  {
+    cs: 'Každou fázi držte alespoň 10 sekund a poté prohlubte ještě na dalších 10 sekund.',
+    en: 'Hold each phase for at least 10 seconds, then deepen it for another 10 seconds.'
+  },
+  {
+    cs: 'Zaměřte se více na strany a svaly, které cítíte jako zkrácené.',
+    en: 'Spend extra attention on sides and muscles that feel restricted.'
+  },
+  {
+    cs: 'Dýchejte přirozeně, nikdy nezadržujte dech.',
+    en: 'Breathe naturally; never hold your breath.'
+  },
+  {
+    cs: 'Asymetrické cviky provádějte na obě strany, abyste udrželi rovnováhu.',
+    en: 'Perform asymmetrical stretches on both sides to stay balanced.'
+  },
+  {
+    cs: 'Ideálně cvičte denně, minimálně však obden; méně než třikrát týdně ztrácí efekt.',
+    en: 'Practice daily if possible, at least every other day; under three times a week loses effect.'
+  },
+  {
+    cs: 'Nikdy nekmitáte ani neskákejte v pozici, zvlášť pokud cítíte diskomfort.',
+    en: 'Never bounce in a stretch, especially when you feel discomfort.'
+  },
+  {
+    cs: 'Pokud ucítíte ostrou nebo přetrvávající bolest, nebo po „lupnutí“, ihned přestaňte.',
+    en: 'Stop immediately if you feel sharp or lasting pain, or after a “pop.”'
+  }
+];

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,639 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f5f5f7;
+  --bg-dark: #111315;
+  --surface: #ffffff;
+  --surface-dark: #1c1f22;
+  --text: #151515;
+  --text-dark: #f7f7f7;
+  --accent: #1f7a8c;
+  --accent-dark: #4ac6e9;
+  --muted: #6b7280;
+  --danger: #b91c1c;
+  --success: #0f766e;
+  --shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+  --radius: 16px;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    background-color: var(--bg-dark);
+    color: var(--text-dark);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, rgba(31, 122, 140, 0.08), transparent 220px);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.top-bar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background-color: rgba(245, 245, 247, 0.9);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+@media (prefers-color-scheme: dark) {
+  .top-bar {
+    background-color: rgba(28, 31, 34, 0.9);
+    border-bottom-color: rgba(148, 163, 184, 0.12);
+  }
+}
+
+.top-bar__inner {
+  margin: 0 auto;
+  max-width: 960px;
+  padding: 0.75rem 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.brand {
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.nav {
+  display: flex;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.nav a {
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  transition: background-color 0.2s ease;
+}
+
+.nav a:focus-visible,
+.nav a:hover {
+  background-color: rgba(31, 122, 140, 0.12);
+}
+
+main#app {
+  margin: 0 auto;
+  max-width: 960px;
+  padding: 1.5rem 1.25rem 5rem;
+}
+
+section {
+  margin-bottom: 2rem;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  font-weight: 700;
+  margin: 0 0 0.75rem;
+}
+
+p {
+  margin: 0 0 1rem;
+  line-height: 1.6;
+}
+
+.card {
+  background-color: var(--surface);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+  position: relative;
+}
+
+@media (prefers-color-scheme: dark) {
+  .card {
+    background-color: var(--surface-dark);
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+  }
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  background-color: var(--accent);
+  color: #ffffff;
+  min-width: 140px;
+}
+
+.btn:hover,
+.btn:focus-visible {
+  box-shadow: 0 10px 20px rgba(31, 122, 140, 0.28);
+  transform: translateY(-1px);
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.btn--secondary {
+  background-color: rgba(31, 122, 140, 0.12);
+  color: var(--accent);
+}
+
+.btn--ghost {
+  background: none;
+  color: inherit;
+  padding: 0.6rem 0.8rem;
+}
+
+.btn--danger {
+  background-color: var(--danger);
+  color: #fff;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.grid.two {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.mini-heatmap {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(30px, 1fr));
+  gap: 0.4rem;
+  margin-top: 1rem;
+}
+
+.mini-heatmap__day {
+  padding: 0.6rem 0.4rem;
+  border-radius: 10px;
+  text-align: center;
+  font-size: 0.8rem;
+  background-color: rgba(148, 163, 184, 0.24);
+  color: inherit;
+}
+
+.mini-heatmap__day.active {
+  background-color: rgba(31, 122, 140, 0.75);
+  color: #fff;
+}
+
+.reminder-banner {
+  margin-top: 1.25rem;
+  padding: 1rem;
+  border-radius: var(--radius);
+  background-color: rgba(31, 122, 140, 0.1);
+}
+
+.rules-link {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-weight: 600;
+}
+
+.session-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.session-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.session-progress {
+  width: 100%;
+  height: 10px;
+  background-color: rgba(148, 163, 184, 0.24);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.session-progress__bar {
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent), #4ac6e9);
+  width: 0%;
+  transition: width 0.3s ease;
+}
+
+.session-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.session-card__image {
+  width: 100%;
+  max-width: 360px;
+  border-radius: 18px;
+  background-color: rgba(148, 163, 184, 0.24);
+  align-self: center;
+}
+
+.session-card__image img {
+  width: 100%;
+  display: block;
+  border-radius: inherit;
+}
+
+.session-info {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.session-info__tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background-color: rgba(31, 122, 140, 0.12);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.timer-display {
+  font-size: 3.25rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+}
+
+.timer-phase {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.side-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+}
+
+.side-indicator svg {
+  width: 1rem;
+  height: 1rem;
+  fill: currentColor;
+}
+
+.cue-list {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.control-bar {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(245, 245, 247, 0.96);
+  backdrop-filter: blur(10px);
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  padding: 0.75rem 1.25rem env(safe-area-inset-bottom);
+}
+
+@media (prefers-color-scheme: dark) {
+  .control-bar {
+    background-color: rgba(28, 31, 34, 0.9);
+    border-top-color: rgba(148, 163, 184, 0.16);
+  }
+}
+
+.control-bar__inner {
+  margin: 0 auto;
+  max-width: 960px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: 0.75rem;
+}
+
+.breath-ticker {
+  text-align: center;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-top: 0.5rem;
+}
+
+.guard-message {
+  color: var(--danger);
+  font-weight: 600;
+  margin-top: 0.5rem;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(15, 23, 42, 0.55);
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  z-index: 50;
+}
+
+.modal {
+  background-color: var(--surface);
+  color: inherit;
+  border-radius: var(--radius);
+  max-width: 640px;
+  width: 100%;
+  max-height: 90vh;
+  overflow: hidden auto;
+  padding: 1.5rem;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
+}
+
+@media (prefers-color-scheme: dark) {
+  .modal {
+    background-color: var(--surface-dark);
+  }
+}
+
+.modal header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.modal ol {
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.modal li span {
+  display: block;
+}
+
+.modal li small {
+  color: var(--muted);
+}
+
+.exercises-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.exercise-item {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: 90px 1fr;
+  padding: 1rem;
+  border-radius: var(--radius);
+  background-color: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+@media (max-width: 640px) {
+  .exercise-item {
+    grid-template-columns: 1fr;
+  }
+}
+
+.exercise-item img {
+  width: 100%;
+  border-radius: 12px;
+}
+
+.exercise-item__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.badge {
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background-color: rgba(31, 122, 140, 0.12);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.settings-form {
+  display: grid;
+  gap: 1.5rem;
+  max-width: 560px;
+}
+
+.settings-group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.settings-group label {
+  font-weight: 600;
+}
+
+select,
+input[type="time"],
+textarea {
+  width: 100%;
+  padding: 0.8rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background-color: var(--surface);
+  color: inherit;
+  font: inherit;
+}
+
+textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.switch input {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  appearance: none;
+  background-color: rgba(148, 163, 184, 0.4);
+  position: relative;
+  outline: none;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.switch input::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background-color: #fff;
+  transition: transform 0.2s ease;
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.2);
+}
+
+.switch input:checked {
+  background-color: rgba(31, 122, 140, 0.75);
+}
+
+.switch input:checked::after {
+  transform: translateX(20px);
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(32px, 1fr));
+  gap: 0.4rem;
+  margin-top: 1rem;
+}
+
+.calendar-cell {
+  padding: 0.8rem 0.4rem;
+  border-radius: 10px;
+  background-color: rgba(148, 163, 184, 0.2);
+  text-align: center;
+  font-size: 0.8rem;
+  min-height: 48px;
+  display: grid;
+  place-items: center;
+}
+
+.calendar-cell[data-count="0"] {
+  opacity: 0.5;
+}
+
+.calendar-cell[data-count="1"] {
+  background-color: rgba(31, 122, 140, 0.35);
+  color: #fff;
+}
+
+.calendar-cell[data-count="2"] {
+  background-color: rgba(31, 122, 140, 0.55);
+  color: #fff;
+}
+
+.calendar-cell[data-count="3"],
+.calendar-cell[data-count="4"],
+.calendar-cell[data-count="5"],
+.calendar-cell[data-count="6"],
+.calendar-cell[data-count="7"],
+.calendar-cell[data-count="8"],
+.calendar-cell[data-count="9"],
+.calendar-cell[data-count="10"] {
+  background-color: rgba(15, 118, 110, 0.8);
+  color: #fff;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.summary-card {
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius);
+  background-color: rgba(31, 122, 140, 0.08);
+  display: grid;
+  gap: 0.25rem;
+}
+
+.note-card {
+  display: grid;
+  gap: 1rem;
+}
+
+.note-card textarea {
+  background-color: rgba(31, 122, 140, 0.08);
+}
+
+.session-done {
+  text-align: center;
+  display: grid;
+  gap: 1rem;
+}
+
+.session-done .btn {
+  justify-self: center;
+}
+
+@media (max-width: 768px) {
+  .nav {
+    display: none;
+  }
+  main#app {
+    padding-bottom: 6.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+:focus-visible {
+  outline: 3px solid rgba(31, 122, 140, 0.6);
+  outline-offset: 3px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.noscript {
+  margin: 2rem;
+  padding: 1rem;
+  border-radius: var(--radius);
+  background-color: rgba(31, 122, 140, 0.15);
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,67 @@
+const CACHE_NAME = 'ssc-cache-v1';
+const ASSETS = [
+  './',
+  './index.html',
+  './styles.css',
+  './app.js',
+  './router.js',
+  './i18n.js',
+  './src/rules.js',
+  './data/exercises.json',
+  './assets/Suzukiho-strecink.pdf',
+  './assets/exercises/placeholder.svg',
+  './assets/icons/play.svg',
+  './assets/icons/pause.svg',
+  './assets/icons/back.svg',
+  './assets/icons/next.svg',
+  './assets/icons/left.svg',
+  './assets/icons/right.svg'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(ASSETS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== CACHE_NAME)
+            .map((key) => caches.delete(key))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+  const requestUrl = new URL(event.request.url);
+  if (requestUrl.origin !== self.location.origin) {
+    return;
+  }
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+      return fetch(event.request)
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+          return response;
+        })
+        .catch(() => cached);
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- update the README to explain that binary assets must be supplied externally
- replace the PDF and exercise image placeholders with text/SVG versions so the repository no longer ships binary files
- retarget exercise metadata and service worker caches to the SVG placeholder asset

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4cb1dec8083258440b30d95d7976e